### PR TITLE
Escape ampersand in metainfo.xml

### DIFF
--- a/io.github.gnu_octave.pkg-control.metainfo.xml
+++ b/io.github.gnu_octave.pkg-control.metainfo.xml
@@ -33,7 +33,7 @@ without any warranty.
     </p>
   </description>
   <url type="homepage">https://gnu-octave.github.io/packages/control/</url>
-  <url type="bugtracker">https://octave.space/savannah/?Action=get&Format=HTMLCSS&Title=[octave%20forge]%20(control)</url>
+  <url type="bugtracker">https://octave.space/savannah/?Action=get&amp;Format=HTMLCSS&amp;Title=[octave%20forge]%20(control)</url>
   <metadata_license>FSFAP</metadata_license>
   <project_license>GPL-3.0-or-later and BSD-3-Clause</project_license>
   <developer_name>Octave Community</developer_name>


### PR DESCRIPTION
Currently the Fedora package build fails with:
```
+ appstream-util validate-relax --nonet /home/orion/BUILDROOT/octave-control-4.0.0-1.fc41.x86_64//usr/share/metainfo/octave-control.metainfo.xml
/home/orion/BUILDROOT/octave-control-4.0.0-1.fc41.x86_64//usr/share/metainfo/octave-control.metainfo.xml: failed to parse /home/orion/BUILDROOT/octave-control-4.0.0-1.fc41.x86_64//usr/share/metainfo/octave-control.metainfo.xml: Error on line 27: Entity did not end with a semicolon; most likely you used an ampersand character without intending to start an entity — escape ampersand as &amp;
```