### PR TITLE
Fix bug #67490

### DIFF
--- a/inst/bode.m
+++ b/inst/bode.m
@@ -127,7 +127,7 @@ function [mag_r, pha_r, w_r] = bode (varargin)
     mag_args = horzcat (cellfun (@horzcat, w, mag_db, sty, "uniformoutput", false){:});
     pha_args = horzcat (cellfun (@horzcat, w, pha, sty, "uniformoutput", false){:});
 
-    subplot (2, 1, 1)
+    hax1 = subplot (2, 1, 1)
     semilogx (mag_args{:})
     axis ("tight")
     ylim (__axis_margin__ (ylim))
@@ -144,6 +144,9 @@ function [mag_r, pha_r, w_r] = bode (varargin)
     xlabel ("Frequency [rad/s]")
     ylabel ("Phase [deg]")
     legend (leg)
+
+    ## Make top axes current for ML compatibility
+    set (gcf, "currentaxes", hax1);
 
   else
 

--- a/inst/bode.m
+++ b/inst/bode.m
@@ -134,7 +134,6 @@ function [mag_r, pha_r, w_r] = bode (varargin)
     grid ("on")
     title ("Bode Diagram")
     ylabel ("Magnitude [dB]")
-    legend (leg)
 
     subplot (2, 1, 2)
     semilogx (pha_args{:})
@@ -143,7 +142,6 @@ function [mag_r, pha_r, w_r] = bode (varargin)
     grid ("on")
     xlabel ("Frequency [rad/s]")
     ylabel ("Phase [deg]")
-    legend (leg)
 
     ## Make top axes current for ML compatibility
     set (gcf, "currentaxes", hax1);


### PR DESCRIPTION
Hi,
This PR removes the default legend in bode.m and makes the top axes current, as proposed in comment 1 of [bug #67490](https://savannah.gnu.org/bugs/?67490)