### PR TITLE
Update lic notice from statistics to control

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ The **control** package is distributed under [GNU General Public License (GPL)](
 ```bash
 ## Copyright (C) YEAR NAME <E-MAIL>
 ##
-## This file is part of the statistics package for GNU Octave.
+## This file is part of the control package for GNU Octave.
 ##
 ## Octave is free software; you can redistribute it and/or modify it
 ## under the terms of the GNU General Public License as published by


### PR DESCRIPTION
It was pointed out in https://github.com/gnu-octave/pkg-control/pull/31#discussion_r3530857870 that the `CONTRIBUTION.md` improperly uses statistics instead of control in the license description. 