### PR TITLE
Correctly combine zpk systems

### DIFF
--- a/inst/@zpk/__ctranspose__.m
+++ b/inst/@zpk/__ctranspose__.m
@@ -20,9 +20,9 @@
 ## Complex-conjugate transpose ZPK model by delegating to TF.
 
 ## Author: Mitchell Thompkins <mitchell.thompkins@pm.me>
-## Created: June 2026
-## Version: 0.1
+## Created: July 2026
+## Version: 0.2
 
 function sys = __ctranspose__ (sys, ct)
-  sys = __ctranspose__ (tf (sys), ct);
+  sys = zpk (__ctranspose__ (tf (sys), ct));
 endfunction

--- a/inst/@zpk/__minreal__.m
+++ b/inst/@zpk/__minreal__.m
@@ -20,9 +20,9 @@
 ## Return minimal realization of ZPK model by delegating to TF.
 
 ## Author: Mitchell Thompkins <mitchell.thompkins@pm.me>
-## Created: June 2026
-## Version: 0.1
+## Created: July 2026
+## Version: 0.2
 
 function sys = __minreal__ (sys, tol)
-  sys = __minreal__ (tf (sys), tol);
+  sys = zpk (__minreal__ (tf (sys), tol));
 endfunction

--- a/inst/@zpk/__sys_connect__.m
+++ b/inst/@zpk/__sys_connect__.m
@@ -20,9 +20,9 @@
 ## Connect ZPK model in a block diagram by delegating to TF.
 
 ## Author: Mitchell Thompkins <mitchell.thompkins@pm.me>
-## Created: June 2026
-## Version: 0.1
+## Created: July 2026
+## Version: 0.2
 
-function sys = __sys_connect__ (sys, m)
-  sys = __sys_connect__ (tf (sys), m);
+function sys = __sys_connect__ (sys, M)
+  sys = zpk (__sys_connect__ (tf (sys), M));
 endfunction

--- a/inst/@zpk/__sys_group__.m
+++ b/inst/@zpk/__sys_group__.m
@@ -17,18 +17,30 @@
 ## see <http://www.gnu.org/licenses/>.
 
 ## -*- texinfo -*-
-## Group (stack) two ZPK models by delegating to TF.
+## Block diagonal concatenation of two ZPK models.
 
 ## Author: Mitchell Thompkins <mitchell.thompkins@pm.me>
-## Created: June 2026
-## Version: 0.1
+## Created: July 2026
+## Version: 0.2
 
 function retsys = __sys_group__ (sys1, sys2)
-  if (isa (sys1, "zpk"))
-    sys1 = tf (sys1);
+  [sys1, sys2] = __numeric_to_lti__ (sys1, sys2);
+
+  if (! isa (sys1, "zpk"))
+    sys1 = zpk (sys1);
   endif
-  if (isa (sys2, "zpk"))
-    sys2 = tf (sys2);
+  if (! isa (sys2, "zpk"))
+    sys2 = zpk (sys2);
   endif
-  retsys = __sys_group__ (sys1, sys2);
+
+  [p1, m1] = size (sys1);
+  [p2, m2] = size (sys2);
+
+  z = [sys1.z, cell(p1, m2); cell(p2, m1), sys2.z];
+  p = [sys1.p, cell(p1, m2); cell(p2, m1), sys2.p];
+  k = [sys1.k, zeros(p1, m2); zeros(p2, m1), sys2.k];
+
+  ltisys = __lti_group__ (sys1.lti, sys2.lti);
+
+  retsys = class (struct ("z", {z}, "p", {p}, "k", k), "zpk", ltisys);
 endfunction

--- a/inst/@zpk/__sys_inverse__.m
+++ b/inst/@zpk/__sys_inverse__.m
@@ -20,9 +20,9 @@
 ## Invert ZPK model by delegating to TF.
 
 ## Author: Mitchell Thompkins <mitchell.thompkins@pm.me>
-## Created: June 2026
-## Version: 0.1
+## Created: July 2026
+## Version: 0.2
 
 function sys = __sys_inverse__ (sys)
-  sys = __sys_inverse__ (tf (sys));
+  sys = zpk (__sys_inverse__ (tf (sys)));
 endfunction

--- a/inst/@zpk/__times__.m
+++ b/inst/@zpk/__times__.m
@@ -17,18 +17,33 @@
 ## see <http://www.gnu.org/licenses/>.
 
 ## -*- texinfo -*-
-## Multiply two ZPK models by delegating to TF.
+## Multiply two ZPK models element-wise.
 
 ## Author: Mitchell Thompkins <mitchell.thompkins@pm.me>
-## Created: June 2026
-## Version: 0.1
+## Created: July 2026
+## Version: 0.2
 
 function sys = __times__ (sys1, sys2)
-  if (isa (sys1, "zpk"))
-    sys1 = tf (sys1);
+  if (! isa (sys1, "zpk"))
+    sys1 = zpk (sys1);
   endif
-  if (isa (sys2, "zpk"))
-    sys2 = tf (sys2);
+  if (! isa (sys2, "zpk"))
+    sys2 = zpk (sys2);
   endif
-  sys = __times__ (sys1, sys2);
+
+  [p1, m1] = size (sys1);
+  [p2, m2] = size (sys2);
+
+  if (p1 != p2 || m1 != m2)
+    error ("zpk: __times__: system dimensions incompatible: (%dx%d) .* (%dx%d)",
+            p1, m1, p2, m2);
+  endif
+
+  z = cellfun (@(a, b) [a; b], sys1.z, sys2.z, "uniformoutput", false);
+  p = cellfun (@(a, b) [a; b], sys1.p, sys2.p, "uniformoutput", false);
+  k = sys1.k .* sys2.k;
+
+  ltisys = __lti_group__ (sys1.lti, sys2.lti, "times");
+
+  sys = class (struct ("z", {z}, "p", {p}, "k", k), "zpk", ltisys);
 endfunction

--- a/inst/@zpk/__transpose__.m
+++ b/inst/@zpk/__transpose__.m
@@ -20,9 +20,9 @@
 ## Transpose ZPK model by delegating to TF.
 
 ## Author: Mitchell Thompkins <mitchell.thompkins@pm.me>
-## Created: June 2026
-## Version: 0.1
+## Created: July 2026
+## Version: 0.2
 
 function sys = __transpose__ (sys)
-  sys = __transpose__ (tf (sys));
+  sys = zpk (__transpose__ (tf (sys)));
 endfunction

--- a/inst/@zpk/zpk.m
+++ b/inst/@zpk/zpk.m
@@ -199,3 +199,87 @@ endfunction
 %! assert (isa (sys, 'zpk'));
 %! [~, p] = zpkdata (sys, 'v');
 %! assert (sort (real (p)), [-2; -1], 1e-10);
+
+%!test
+%! ## series of two zpk systems stays zpk with correct z, p, k
+%! sys1 = zpk ([-1], [-2, -3], 5);
+%! sys2 = zpk ([-4], [-5], 2);
+%! sys = series (sys1, sys2);
+%! assert (isa (sys, 'zpk'));
+%! [z, p, k] = zpkdata (sys, 'v');
+%! assert (sort (real (z)), [-4; -1], 1e-10);
+%! assert (sort (real (p)), [-5; -3; -2], 1e-10);
+%! assert (k, 10, 1e-10);
+
+%!test
+%! ## feedback of two zpk systems stays zpk
+%! sys1 = zpk ([-1], [-2, -3], 5);
+%! sys2 = zpk ([-4], [-5], 2);
+%! sys = feedback (sys1, sys2);
+%! assert (isa (sys, 'zpk'));
+%! [z, p, k] = zpkdata (sys, 'v');
+%! sys_tf = feedback (tf (sys1), tf (sys2));
+%! [z_ref, p_ref, k_ref] = zpkdata (zpk (sys_tf), 'v');
+%! assert (sort (real (z)), sort (real (z_ref)), 1e-6);
+%! assert (sort (real (p)), sort (real (p_ref)), 1e-6);
+%! assert (k, k_ref, 1e-6);
+
+%!test
+%! ## parallel of two zpk systems stays zpk with correct z, p, k
+%! sys1 = zpk ([-1], [-2, -3], 5);
+%! sys2 = zpk ([-4], [-5], 2);
+%! sys = sys1 + sys2;
+%! assert (isa (sys, 'zpk'));
+%! [z, p, k] = zpkdata (sys, 'v');
+%! z_ref = [-1.32743980871762; ...
+%!          -5.08628009564119 - 1.27526210411816i; ...
+%!          -5.08628009564119 + 1.27526210411816i];
+%! assert (sort (real (z)), sort (real (z_ref)), 1e-6);
+%! assert (sort (imag (z)), sort (imag (z_ref)), 1e-6);
+%! assert (sort (real (p)), [-5; -3; -2], 1e-10);
+%! assert (k, 2, 1e-10);
+
+%!test
+%! ## element-wise product of two zpk systems stays zpk with correct z, p, k
+%! sys1 = zpk ([-1], [-2, -3], 5);
+%! sys2 = zpk ([-4], [-5], 2);
+%! sys = sys1 .* sys2;
+%! assert (isa (sys, 'zpk'));
+%! [z, p, k] = zpkdata (sys, 'v');
+%! assert (sort (real (z)), [-4; -1], 1e-10);
+%! assert (sort (real (p)), [-5; -3; -2], 1e-10);
+%! assert (k, 10, 1e-10);
+
+%!test
+%! ## transpose of a zpk system stays zpk
+%! sys = zpk ({[-1]; [-2]}, {[-3]; [-4]}, [5; 6]);
+%! sys_t = sys.';
+%! assert (isa (sys_t, 'zpk'));
+%! assert (size (sys_t), [1, 2]);
+
+%!test
+%! ## ctranspose of a zpk system stays zpk
+%! sys = zpk ({[-1]; [-2]}, {[-3]; [-4]}, [5; 6]);
+%! sys_ct = sys';
+%! assert (isa (sys_ct, 'zpk'));
+%! assert (size (sys_ct), [1, 2]);
+
+%!test
+%! ## minreal of a zpk system cancels the common pole/zero and stays zpk
+%! sys = zpk ([-1], [-1, -2], 3);
+%! sys_mr = minreal (sys);
+%! assert (isa (sys_mr, 'zpk'));
+%! [z, p, k] = zpkdata (sys_mr, 'v');
+%! assert (isempty (z));
+%! assert (p, -2, 1e-6);
+%! assert (k, 3, 1e-6);
+
+%!test
+%! ## inverse of a zpk system stays zpk
+%! sys = zpk ([-1], [-2], 3);
+%! sys_inv = inv (sys);
+%! assert (isa (sys_inv, 'zpk'));
+%! [z, p, k] = zpkdata (sys_inv, 'v');
+%! assert (z, -2, 1e-6);
+%! assert (p, -1, 1e-6);
+%! assert (k, 1/3, 1e-6);


### PR DESCRIPTION
# Description 

https://github.com/gnu-octave/pkg-control/pull/31#issuecomment-4917739254 pointed out that

> the combination (series, feedback) of two systems represented in zpk form results in a system in tf form

This is of course wrong and I've tried to address it here. While addressing I also realized a number of functions were also returning `tf` data types because they delegate to `tf`. That's of course also wrong because when you work with `zpk` you should expect to stay in that data type (even if the backing implementation degrades to another system representation).

# Changes

- For all the new `zpk` data types they all actually return `zpk`.
- `__times__` (.*), `__sys_group__` (+) now return the correct types and data shape (I think)
- Added more tests to tests all of these things