### PR TITLE
Minor tooling and docs fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,8 @@ check-ci: tarball-nodocs
 	$(OCTAVE) --no-gui devel/run_tests.m
 
 check-local:
-	docker compose --file devel/compose.yaml --project-directory . run --rm octave
+	HOST_UID=$(shell id -u) HOST_GID=$(shell id -g) \
+	  docker compose --file devel/compose.yaml --project-directory . run --rm octave
 
 tarball-nodocs: $(RELEASE_TARBALL_CI)
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This is the official repository for the control package for GNU Octave.
 
 ## About
 
-The **control** package is a collection of functions for control systems design and analysis. 
+The **control** package is a collection of functions for control systems design and analysis.
 
-As of 24.03.2023, the developemnt of the **control** package was moved from [SourceForge](https://sourceforge.net/p/octave/control/ci/default/tree/) and [Mercurial](https://en.wikipedia.org/wiki/Mercurial) to [GitHub](https://github.com/gnu-octave/pkg-control) and [Git](https://en.wikipedia.org/wiki/Git). Links related to the control package
+As of 24.03.2023, the development of the **control** package was moved from [SourceForge](https://sourceforge.net/p/octave/control/ci/default/tree/) and [Mercurial](https://en.wikipedia.org/wiki/Mercurial) to [GitHub](https://github.com/gnu-octave/pkg-control) and [Git](https://en.wikipedia.org/wiki/Git). Links related to the control package
 
 - [License and copyright information](https://github.com/gnu-octave/pkg-control/blob/main/COPYING)
 - [Releases](https://github.com/gnu-octave/pkg-control/releases)
@@ -46,9 +46,9 @@ You can also clone this repository (using the option `--recurse-submodules` sinc
 
 - `make dist`<br>
   Create the package archive file in the directory `target` which can be installed
-  in Octave afterwards. If `make DOCS_EXAMPLES=true dist` is used, the documentation   
+  in Octave afterwards. If `make DOCS_EXAMPLES=true dist` is used, the documentation
   files (pdf and qch for Octave's documentation browser) will contain the demos of
-  the package as examples togehter with the resulting plots. However, for this the
+  the package as examples together with the resulting plots. However, for this the
   control package has to be installed.
 - `make install`<br>
   Install the package

--- a/devel/compose.yaml
+++ b/devel/compose.yaml
@@ -2,6 +2,7 @@ services:
   octave:
     image: gnuoctave/octave:latest
     working_dir: /workspace
+    user: "${HOST_UID}:${HOST_GID}"
     volumes:
-      - .:/workspace
+      - .:/workspace:z
     command: make check-ci

--- a/devel/compose.yaml
+++ b/devel/compose.yaml
@@ -2,7 +2,7 @@ services:
   octave:
     image: gnuoctave/octave:latest
     working_dir: /workspace
-    user: "${HOST_UID}:${HOST_GID}"
+    user: "${HOST_UID:?set HOST_UID or run via make check-local, not docker compose directly}:${HOST_GID:?set HOST_GID or run via make check-local, not docker compose directly}"
     volumes:
       - .:/workspace:z
     command: make check-ci


### PR DESCRIPTION
- `compose.yaml`: add the `:z` SELinux relabeling flag to the bind mount, so `devel/compose.yaml` works out of the box on SELinux-enforcing hosts (Fedora, RHEL, etc.) instead of silently hitting permission-denied errors.
- `check-local`: run the container as the host user instead of root, so files created during `make check-local` aren't root-owned on the host afterward.
- `README.md`: fix typos and trailing whitespace.

No functional changes to pkg-control itself.